### PR TITLE
Aggiunto esempio attributo da dbsql eduPersonOrcid

### DIFF
--- a/roles/mariadb/files/insert-userorcid.sql
+++ b/roles/mariadb/files/insert-userorcid.sql
@@ -1,0 +1,5 @@
+INSERT INTO user_orcid (uid, orcid, start_date, end_date) VALUES
+       ('mario', 'http://orcid.org/0000-0002-1825-0097', STR_TO_DATE('2010-05-01', '%Y-%m-%d'), STR_TO_DATE('9999-12-31', '%Y-%m-%d')),
+       ('mario', 'http://orcid.org/0000-0001-9351-8252', STR_TO_DATE('2012-07-11', '%Y-%m-%d'), STR_TO_DATE('9999-12-31', '%Y-%m-%d')),
+       ('mario', 'http://orcid.org/0000-0001-9351-1111', STR_TO_DATE('2015-01-01', '%Y-%m-%d'), STR_TO_DATE('2019-12-31', '%Y-%m-%d')),
+       ('gino', 'http://orcid.org/0000-0001-9351-5432', STR_TO_DATE('2010-01-01', '%Y-%m-%d'), STR_TO_DATE('9999-12-31', '%Y-%m-%d'));

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -47,3 +47,22 @@
   file:
     state: absent
     path: "{{ tmp_upload_dir }}/insert-ruoliorganizzativi.sql"
+
+- name: Check table user_orcid
+  shell: "echo 'SELECT * FROM user_orcid' | mariadb -u {{ idp_rdbms_user }} --password={{ idp_rdbms_pw }} {{ idp_rdbms_dbname }}"
+  register: ruoli_org
+
+- name: Copy temporary insert-userorcid.sql
+  copy:
+    src: roles/{{ role_name }}/files/insert-userorcid.sql
+    dest: "{{ tmp_upload_dir }}/insert-userorcid.sql"
+
+- name: Load table user_orcid
+  shell: "mariadb -u root {{ idp_rdbms_dbname }} < {{ tmp_upload_dir }}/insert-userorcid.sql"
+  # shell: "mariadb -u root --password={{ idp_rdbms_pw }} {{ idp_rdbms_dbname }} < {{ tmp_upload_dir }}/insert-userorcid.sql"
+  when: ruoli_org.stdout == ""
+
+- name: Clean temporary insert-userorcid.sql
+  file:
+    state: absent
+    path: "{{ tmp_upload_dir }}/insert-userorcid.sql"

--- a/roles/mariadb/templates/shibboleth.sql
+++ b/roles/mariadb/templates/shibboleth.sql
@@ -40,3 +40,11 @@ uid VARCHAR(255) NOT NULL,
 ruolo VARCHAR(255) NOT NULL,
 PRIMARY KEY (id)
 );
+
+create table user_orcid (
+uid varchar(128) not null,
+orcid varchar(128) not null,
+start_date date,
+end_date  date,
+PRIMARY KEY (uid, orcid, start_date)
+);

--- a/roles/shib3idp_configure/files/attribute-resolver-dbsql.xml
+++ b/roles/shib3idp_configure/files/attribute-resolver-dbsql.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+    This file is an EXAMPLE configuration file. While the configuration
+    presented in this example file is semi-functional, it isn't very
+    interesting. It is here only as a starting point for your deployment
+    process.
+    
+    Very few attribute definitions and data connectors are demonstrated,
+    and the data is derived statically from the logged-in username and a
+    static example connector.
+
+    Attribute-resolver-full.xml contains more examples of attributes,
+    encoders, and data connectors. Deployers should refer to the Shibboleth
+    documentation for a complete list of components and their options.
+-->
+<AttributeResolver
+        xmlns="urn:mace:shibboleth:2.0:resolver" 
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+        xsi:schemaLocation="urn:mace:shibboleth:2.0:resolver http://shibboleth.net/schema/idp/shibboleth-attribute-resolver.xsd">
+
+
+    <!-- ========================================== -->
+    <!--      Attribute Definitions                 -->
+    <!-- ========================================== -->
+
+
+    <AttributeDefinition xsi:type="Simple" id="eduPersonOrcid">
+        <InputDataConnector ref="mySqlOrcidConnector" attributeNames="orcidDbsql"/>
+        <DisplayName xml:lang="en">ORCID</DisplayName>
+        <DisplayName xml:lang="it">ORCID</DisplayName>
+        <DisplayDescription xml:lang="en">ORCID user identifier released and managed by orcid.org</DisplayDescription>
+        <DisplayDescription xml:lang="it">Identificativi ricercatore ORCID dell’utente assegnati e gestiti da orcid.org</DisplayDescription>
+        <AttributeEncoder xsi:type="SAML2String" name="urn:oid:1.3.6.1.4.1.5923.1.1.1.16" friendlyName="eduPersonOrcid" encodeType="false"/>
+    </AttributeDefinition>	
+	
+
+    <!-- ========================================== -->
+    <!--      Data Connectors                       -->
+    <!-- ========================================== -->
+
+	
+    <!-- mySql UCPPool -->
+    <!-- https://wiki.shibboleth.net/confluence/display/IDP30/BeanManagedConnection -->
+	<!-- https://wiki.shibboleth.net/confluence/display/IDP30/RelationalDatabaseConnector -->
+    <DataConnector id="mySqlOrcidConnector" xsi:type="RelationalDatabase" >   
+    	
+    	<InputAttributeDefinition ref="uid" />
+            
+        <BeanManagedConnection>MyDataSource</BeanManagedConnection>        
+        <QueryTemplate>
+        <![CDATA[
+		 select orcid from user_orcid where lcase(trim(uid)) = lcase(trim('$uid[0]')) and curdate() between start_date and end_date
+        ]]>
+        </QueryTemplate>        
+        <Column columnName="orcid" attributeID="orcidDbsql" />        
+    </DataConnector>	
+
+</AttributeResolver>

--- a/roles/shib3idp_configure/tasks/main.yml
+++ b/roles/shib3idp_configure/tasks/main.yml
@@ -84,6 +84,12 @@
     dest: "{{ idp_path }}/conf/attribute-resolver-dynamic.xml"
     backup: yes
 
+- name: Copy configured attribute-resolver-dbsql.xml
+  copy:
+    src: "roles/shib3idp_configure/files/attribute-resolver-dbsql.xml"
+    dest: "{{ idp_path }}/conf/attribute-resolver-dbsql.xml"
+    backup: yes
+
 - name: Update services.xml
   blockinfile:
     path: "{{ idp_path }}/conf/services.xml"
@@ -92,6 +98,7 @@
     block: |8
               <value>%{idp.home}/conf/{{ idp_attr_resolver }}</value>
               <value>%{idp.home}/conf/attribute-resolver-dynamic.xml</value>
+              <value>%{idp.home}/conf/attribute-resolver-dbsql.xml</value>
     backup: yes
 
 # these replace will be overwritten by next task if idp_persistent_id_rdbms == true

--- a/roles/shib3idp_configure/templates/attribute-filter-local.xml
+++ b/roles/shib3idp_configure/templates/attribute-filter-local.xml
@@ -77,6 +77,10 @@
             <PermitValueRule xsi:type="ANY" />
         </AttributeRule>
 
+        <AttributeRule attributeID="eduPersonOrcid">
+            <PermitValueRule xsi:type="ANY" />
+        </AttributeRule>
+
         <AttributeRule attributeID="email">
             <PermitValueRule xsi:type="ANY" />
         </AttributeRule>

--- a/roles/shib3sp/files/attribute-map.xml
+++ b/roles/shib3sp/files/attribute-map.xml
@@ -160,6 +160,7 @@
 <!-- Attributi aggiunti per il corso IdP 2016-06-16  --> 
     <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.9" id="schacHomeOrganization"/>
     <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.10" id="schacHomeOrganizationType"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.16" id="eduPersonOrcid"/>
     <Attribute name="miaOrganizzazione:adGroup" id="ActiveDir_group"/>
     <Attribute name="miaOrganizzazione:adMail" id="Additional_mail"/>
     <Attribute name="ORGANIZZAZIONE_servizioX_codice" id="codiceaccesso"/>


### PR DESCRIPTION
Modifiche alla configurazione:
- creata una tabella user_orcid in mysql con un set di valori di esempio (3 orcid per mario di cui 2 soli validi ad oggi, e 1 per gino)
- creato file attribute-resolver-dbsql.xml
- aggiunta riga in services.xml per includere attribute-resolver-dbsql.xml
- aggiunto filtro eduPersonOrcid in attribute-filter-local.xml
- aggiunto attributo eduPersonOrcid in attribute-map.xml dell'sp
- aggiornato playbook